### PR TITLE
Version fixes: downgrade numpy, enable python 3.9

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -28,7 +28,7 @@ class FishEvent:
 
     # initialize these
     action_key = 'e'
-    collect_r = False
+    collect_allow_auto = False
     uid = None
     sound = False
 
@@ -36,6 +36,8 @@ class FishEvent:
 def init():
     subscribe()
     FishEvent.action_key = config.get("action_key", 'e')
+    FishEvent.collect_key = config.get("collect_key", 'r')
+    FishEvent.collect_allow_auto = config.get("collect_allow_auto", False)
     FishEvent.uid = config.get("uid")
     FishEvent.sound = config.get("sound_notification", False)
 
@@ -74,9 +76,10 @@ def on_hook():
 
     keyboard.press_and_release(FishEvent.action_key)
 
-    if FishEvent.collect_r:
+    if FishEvent.collect_allow_auto:
         time.sleep(0.1)
         keyboard.press_and_release('r')
+        logging.info("AUTO-LOOT")
         time.sleep(0.1)
 
 

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -50,6 +50,8 @@ def start_fullfisher_config(gui: 'GUI'):
 def start_semifisher_config(gui: 'GUI'):
     def save():
         gui.config.set("action_key", action_key_entry.get(), False)
+        gui.config.set("collect_key", collect_key_entry.get(), False)
+        gui.config.set("collect_allow_auto", collect_allow_auto.instate(['selected']), False)
         gui.config.set("borderless", borderless.instate(['selected']), False)
         gui.config.set("sound_notification", sound.instate(['selected']), False)
         gui.config.save_config()
@@ -86,9 +88,18 @@ def start_semifisher_config(gui: 'GUI'):
     action_key_entry.grid(row=2, column=1)
     action_key_entry.insert(0, config.get("action_key", "e"))
 
-    Label(controls_frame, text="Sound Notification: ").grid(row=3, column=0, pady=(5, 5))
+    Label(controls_frame, text="Auto-Looting: ").grid(row=3, column=0, pady=(5, 5))
+    collect_allow_auto = Checkbutton(controls_frame, var=BooleanVar(value=config.get("collect_allow_auto")))
+    collect_allow_auto.grid(row=3, column=1)
+    
+    Label(controls_frame, text="Looting Key:").grid(row=4, column=0)
+    collect_key_entry = Entry(controls_frame, justify=CENTER)
+    collect_key_entry.grid(row=4, column=1)
+    collect_key_entry.insert(0, config.get("collect_key", "r"))
+
+    Label(controls_frame, text="Sound Notification: ").grid(row=5, column=0, pady=(5, 5))
     sound = Checkbutton(controls_frame, var=BooleanVar(value=config.get("sound_notification")))
-    sound.grid(row=3, column=1)
+    sound.grid(row=5, column=1)
 
     controls_frame.pack(padx=(5, 5), pady=(5, 5))
     top.start()

--- a/fishy/gui/terms_gui.py
+++ b/fishy/gui/terms_gui.py
@@ -1,6 +1,7 @@
 import webbrowser
 from tkinter import *
 from tkinter.ttk import *
+import re
 
 from PIL import Image, ImageTk
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 urllib3
 winshell
 imutils
-numpy
+numpy==1.19.3
 opencv_python
 Pillow
 pypiwin32


### PR DESCRIPTION
This PR aims to make fishy fit for use on windows, especially with current python 3.9.

Problems:

- The numpy library Version 1.19.4 has an error on windows, thus a downgrade to numpy 1.19.4 is done in requirements.txt to allow easy installation. This is temporary and should be eliminated, once the problem is fixed in numpy.
- Python 3.9 expects an explicit import of the re library, which apparently is not needed but allowed in 3.7

Testing:

- install python 3.7, reinstall fishy, make sure everything still works 
- install python 3.9, reinstall fishy, make sure everything works out of the box with no error that "re" is unknown.