### PR TITLE
Version fixes: downgrade numpy, enable python 3.9

### DIFF
--- a/fishy/gui/terms_gui.py
+++ b/fishy/gui/terms_gui.py
@@ -1,6 +1,7 @@
 import webbrowser
 from tkinter import *
 from tkinter.ttk import *
+import re
 
 from PIL import Image, ImageTk
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 urllib3
 winshell
 imutils
-numpy
+numpy==1.19.3
 opencv_python
 Pillow
 pypiwin32


### PR DESCRIPTION
This PR aims to make fishy fit for use on windows, especially with current python 3.9.
NOTE: I had to reopen the PR to change the source branch.

Problems:

The numpy library Version 1.19.4 has an error on windows, thus a downgrade to numpy 1.19.3 is done in requirements.txt to allow easy installation. This is temporary and should be eliminated, once the problem is fixed in numpy.
Python 3.9 expects an explicit import of the re library, which apparently is not needed but allowed in 3.7
Testing:

install python 3.7, reinstall fishy, make sure everything still works
install python 3.9, reinstall fishy, make sure everything works out of the box with no error that "re" is unknown.