### PR TITLE
Feature: Auto Looting - Add menu entrys to enable auto loot and change default key

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -28,7 +28,7 @@ class FishEvent:
 
     # initialize these
     action_key = 'e'
-    collect_r = False
+    collect_allow_auto = False
     uid = None
     sound = False
 
@@ -36,6 +36,8 @@ class FishEvent:
 def init():
     subscribe()
     FishEvent.action_key = config.get("action_key", 'e')
+    FishEvent.collect_key = config.get("collect_key", 'r')
+    FishEvent.collect_allow_auto = config.get("collect_allow_auto", False)
     FishEvent.uid = config.get("uid")
     FishEvent.sound = config.get("sound_notification", False)
 
@@ -74,7 +76,7 @@ def on_hook():
 
     keyboard.press_and_release(FishEvent.action_key)
 
-    if FishEvent.collect_r:
+    if FishEvent.collect_allow_auto:
         time.sleep(0.1)
         keyboard.press_and_release('r')
         time.sleep(0.1)

--- a/fishy/gui/config_top.py
+++ b/fishy/gui/config_top.py
@@ -50,6 +50,8 @@ def start_fullfisher_config(gui: 'GUI'):
 def start_semifisher_config(gui: 'GUI'):
     def save():
         gui.config.set("action_key", action_key_entry.get(), False)
+        gui.config.set("collect_key", collect_key_entry.get(), False)
+        gui.config.set("collect_allow_auto", collect_allow_auto.instate(['selected']), False)
         gui.config.set("borderless", borderless.instate(['selected']), False)
         gui.config.set("sound_notification", sound.instate(['selected']), False)
         gui.config.save_config()
@@ -61,6 +63,10 @@ def start_semifisher_config(gui: 'GUI'):
         else:
             if web.sub(config.get("uid")):
                 gui._notify.set(1)
+                
+    def toggle_collect():
+        gui.config.set("collect_allow_auto", collect_allow_auto.instate(['selected']), False)
+        collect_key_entry['state'] = NORMAL if config.get("collect_allow_auto") else DISABLED
 
     top = PopUp(save, gui._root, background=gui._root["background"])
     controls_frame = Frame(top)
@@ -86,9 +92,20 @@ def start_semifisher_config(gui: 'GUI'):
     action_key_entry.grid(row=2, column=1)
     action_key_entry.insert(0, config.get("action_key", "e"))
 
-    Label(controls_frame, text="Sound Notification: ").grid(row=3, column=0, pady=(5, 5))
+
+    Label(controls_frame, text="Auto-Looting: ").grid(row=3, column=0, pady=(15, 0))
+    collect_allow_auto = Checkbutton(controls_frame, command=toggle_collect, var=BooleanVar(value=config.get("collect_allow_auto")))
+    collect_allow_auto.grid(row=3, column=1, pady=(15, 0))
+    
+    Label(controls_frame, text="Looting Key:").grid(row=4, column=0, pady=(0, 15))
+    collect_key_entry = Entry(controls_frame, justify=CENTER)
+    collect_key_entry.grid(row=4, column=1, pady=(0, 15))
+    collect_key_entry.insert(0, config.get("collect_key", "r"))
+    collect_key_entry['state'] = NORMAL if config.get("collect_allow_auto") else DISABLED
+
+    Label(controls_frame, text="Sound Notification: ").grid(row=5, column=0, pady=(5, 5))
     sound = Checkbutton(controls_frame, var=BooleanVar(value=config.get("sound_notification")))
-    sound.grid(row=3, column=1)
+    sound.grid(row=5, column=1)
 
     controls_frame.pack(padx=(5, 5), pady=(5, 5))
     top.start()


### PR DESCRIPTION
This PR adds options to enable auto looting and changing the default key for looting, meaning fishy automatically loots the fish once the inventory opens.

This allows for unattended fishing without toggling the ingame auto-looting on.

Problem:
- I recognized that it does need a restart after toggling auto loot, if this is a no go we should find a solution together.