### PR TITLE
Add messagebox for quit while engine running

### DIFF
--- a/fishy/gui/main_gui.py
+++ b/fishy/gui/main_gui.py
@@ -118,8 +118,8 @@ def _create(gui: 'GUI'):
     # noinspection PyProtectedMember
     def set_destroy():
         if gui._bot_running:
-            logging.info("Turn off the bot engine first")
-            return
+            if(not messagebox.askyesno(title="Quit?", message="Bot engine running. Quit Anyway?")):
+                return
 
         config.set("win_loc", gui._root.geometry())
         gui._destroyed = True


### PR DESCRIPTION
This PR provides means to exit fishy, even when the engine is running.
In order to enhance usability needs, there should always be an easy way out.

I realized the engine has certain buggy states that won't allow stopping.
To allow a user in any case to quit fishy, a messagebox will ask wether or not to quit after pressing the big red X while the engine is in a running state.