### PR TITLE
Fix: sleep time before collecting is to short

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -87,7 +87,7 @@ def on_hook():
     keyboard.press_and_release(FishEvent.action_key)
 
     if FishEvent.collect_allow_auto:
-        _fishing_sleep(0.1)
+        _fishing_sleep(0.15)
         keyboard.press_and_release('r')
         _fishing_sleep(0.1)
     _fishing_sleep(0.0)


### PR DESCRIPTION
In some very seldom cases the auto loot option didn't loot the hole-inventory. See #23 
I found that extending the sleep time does fix the problem for me.

This is probably a client side problem and might still happen to others with slower hardware or beefy eso-addons. If this problem persists for others the time should be extended even more.

Fixes #23 