### PR TITLE
Fix: auto loot has hard coded loot key

### DIFF
--- a/fishy/engine/semifisher/fishing_event.py
+++ b/fishy/engine/semifisher/fishing_event.py
@@ -88,7 +88,7 @@ def on_hook():
 
     if FishEvent.collect_allow_auto:
         _fishing_sleep(0.1)
-        keyboard.press_and_release('r')
+        keyboard.press_and_release(FishEvent.collect_key)
         _fishing_sleep(0.1)
     _fishing_sleep(0.0)
 


### PR DESCRIPTION
This is an important fix for the auto loot feature.
Fishy is using hard coded loot key "r", even though the user can set their own key.
This PR rights my wrong.

Fastest way to test it is to set loot key to the games jump-key, with and without the fix.